### PR TITLE
widget: fix iconSize in bar

### DIFF
--- a/alarmClock/AlarmClockWidget.qml
+++ b/alarmClock/AlarmClockWidget.qml
@@ -36,7 +36,7 @@ PluginComponent {
             DankIcon {
                 name: AlarmService.widgetIcon
                 color: Theme.primary
-                size: Theme.iconSize
+                size: root.iconSize
                 anchors.verticalCenter: parent.verticalCenter
             }
 
@@ -57,7 +57,7 @@ PluginComponent {
             DankIcon {
                 name: AlarmService.widgetIcon
                 color: Theme.primary
-                size: Theme.iconSize
+                size: root.iconSize
                 anchors.horizontalCenter: parent.horizontalCenter
             }
 


### PR DESCRIPTION
Use new helper that makes it easier to reference target icon size for bar widgets.

Fixes the overly large icon in bar.